### PR TITLE
feat: Basic QR Generation

### DIFF
--- a/components/GenerateQR.vue
+++ b/components/GenerateQR.vue
@@ -25,11 +25,22 @@ const saveQRCode = async () => {
 }
 </script>
 
+<style scoped>
+.btn-container {
+  display: flex;
+  justify-content: space-between;
+  padding-top: 1rem;
+}
+</style>
+
 <template>
   <h2>QR Code</h2>
   <qrcode-vue :value="text" :size="200" level="H" />
   <input v-model="text" placeholder="Enter text or URL" />
-  <button @click="saveQRCode">
-    {{ loading ? 'Saving...' : 'Generate & Save QR' }}
-  </button>
+  <div class="btn-container">
+    <NuxtLink to="/dashboard">Back</NuxtLink>
+    <button @click="saveQRCode">
+      {{ loading ? 'Saving...' : 'Generate & Save QR' }}
+    </button>
+  </div>
 </template>

--- a/components/GenerateQR.vue
+++ b/components/GenerateQR.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { ref } from 'vue'
+import QrcodeVue, { QrcodeCanvas, QrcodeSvg } from 'qrcode.vue'
+
+const supabase = useSupabaseClient()
+const loading = ref(false)
+const text = ref('https://www.qrcode.com')
+
+const saveQRCode = async () => {
+  // Set loading to true
+  loading.value = true
+
+  const userID = (await supabase.auth.getUser()).data.user.id
+  const { data, error } = await supabase.from('user_qr_codes').insert({
+    data: text.value,
+    user_id: userID,
+  })
+
+  if (error) {
+    console.error('Error saving QR code:', error)
+  } else {
+    console.log('QR code saved:', data)
+  }
+  loading.value = false
+}
+</script>
+
+<template>
+  <h2>QR Code</h2>
+  <qrcode-vue :value="text" :size="200" level="H" />
+  <input v-model="text" placeholder="Enter text or URL" />
+  <button @click="saveQRCode">
+    {{ loading ? 'Saving...' : 'Generate & Save QR' }}
+  </button>
+</template>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "nuxt-app",
+  "name": "qr-track",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -12,6 +13,7 @@
   "dependencies": {
     "@nuxtjs/supabase": "^1.5.0",
     "nuxt": "^3.16.2",
+    "qrcode.vue": "^3.6.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"
   },

--- a/pages/dashboard/generate/index.vue
+++ b/pages/dashboard/generate/index.vue
@@ -1,0 +1,10 @@
+<script setup>
+const user = useSupabaseUser()
+</script>
+
+<template>
+  <div class="container" style="padding: 50px 0 100px 0">
+    <GenerateQR v-if="user" />
+    <Auth v-else />
+  </div>
+</template>

--- a/supabase/migrations/20250411080038_create_user_qr_code_table.sql
+++ b/supabase/migrations/20250411080038_create_user_qr_code_table.sql
@@ -1,0 +1,52 @@
+create table
+    user_qr_codes (
+        id uuid default uuid_generate_v4 () primary key,
+        user_id uuid references auth.users (id) on delete cascade,
+        data text not null, -- encoded QR data
+        qr_image_url text, -- optional, URL to qr code stored in storage
+        created_at timestamp
+        with
+            time zone default now (),
+            updated_at timestamp
+        with
+            time zone default now (),
+            deleted_at timestamp
+        with
+            time zone
+    );
+
+-- Set up Row Level Security (RLS)
+alter table user_qr_codes enable row level security;
+
+create policy "Users can view their own QR codes" on user_qr_codes for
+select
+    using (
+        user_id = auth.uid ()
+        and deleted_at is null
+    );
+
+create policy "Users can insert their own qr codes." on user_qr_codes for insert
+with
+    check (
+        (
+            select
+                auth.uid ()
+        ) = id
+    );
+
+create policy "Users can update their own qr codes." on user_qr_codes for
+update using (
+    (
+        select
+            auth.uid ()
+    ) = id
+);
+
+-- This trigger automatically updates the `update_atd` column whenever a row changes
+create or replace function public.update_updated_at_column()
+returns trigger as $$
+begin
+  NEW.updated_at = now();
+  return NEW;
+end;
+$$ language plpgsql;

--- a/supabase/migrations/20250411104824_set_user_id_to_not_null_for_user_qr_code.sql
+++ b/supabase/migrations/20250411104824_set_user_id_to_not_null_for_user_qr_code.sql
@@ -1,0 +1,4 @@
+alter table user_qr_codes
+alter column user_id
+set
+    not null;

--- a/supabase/migrations/20250411113226_update_rls_allow_auth_users_for_user_qr_codes.sql
+++ b/supabase/migrations/20250411113226_update_rls_allow_auth_users_for_user_qr_codes.sql
@@ -1,0 +1,3 @@
+alter policy "Enable insert for authenticated users only" on "public"."user_qr_codes" to authenticated
+with
+    check (true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3644,6 +3644,11 @@ protocols@^2.0.0, protocols@^2.0.1:
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-2.0.2.tgz#822e8fcdcb3df5356538b3e91bfd890b067fd0a4"
   integrity sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==
 
+qrcode.vue@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/qrcode.vue/-/qrcode.vue-3.6.0.tgz#d940fe96712922232aa19892bdd68793e62c73e7"
+  integrity sha512-vQcl2fyHYHMjDO1GguCldJxepq2izQjBkDEEu9NENgfVKP6mv/e2SU62WbqYHGwTgWXLhxZ1NCD1dAZKHQq1fg==
+
 quansync@^0.2.8:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/quansync/-/quansync-0.2.10.tgz#32053cf166fa36511aae95fc49796116f2dc20e1"


### PR DESCRIPTION
This PR adds the following
- A `generate` QR page that users can use to generate QR codes. This record is saved in DB.
- DB migration to include saving the record in the DB.